### PR TITLE
reactのアプリをvercelにデプロイするための設定

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{"source": "/(.*)", "destination": "/"}]
+}


### PR DESCRIPTION
## 実装内容
vercel.jsonでの設定追加

具体的には
・vercelでreactアプリをデプロイすると、idのあるページに遷移した際に404エラーになってしまうバグがあるためその対処

## 問題
なし

## 断念・妥協・未実装
なし

## メモ
セクション12